### PR TITLE
Allow overriding of randomly generated GUIDs to ease persistance

### DIFF
--- a/jquery.bonsai.js
+++ b/jquery.bonsai.js
@@ -21,7 +21,7 @@
     addExpandAll: false, // add a link to expand all items
     addSelectAll: false, // add a link to select all checkboxes
     selectAllExclude: null, // a filter selector or function for selectAll
-    guid: null, // optional fixed gui to allow for persistence
+    guid: null, // optional fixed guid to allow for persistence
 
     checkboxes: false, // requires jquery.qubit
     // createCheckboxes: creates checkboxes for each list item.

--- a/jquery.bonsai.js
+++ b/jquery.bonsai.js
@@ -21,6 +21,7 @@
     addExpandAll: false, // add a link to expand all items
     addSelectAll: false, // add a link to select all checkboxes
     selectAllExclude: null, // a filter selector or function for selectAll
+    guid: null, // optional fixed gui to allow for persistence
 
     checkboxes: false, // requires jquery.qubit
     // createCheckboxes: creates checkboxes for each list item.
@@ -42,7 +43,7 @@
     this.options = $.extend({}, $.bonsai.defaults, options);
     this.el = $(el).addClass('bonsai').data('bonsai', this);
 
-    this.guid = Math.round(Math.random()*1e8);
+    this.guid = ( this.options.guid ? this.options.guid : Math.round(Math.random()*1e8) );
     this.generatedIdPrefix = 'bonsai-generated-' + this.guid + '-';
     this.specifiedIdPrefix = 'bonsai-specified-' + this.guid + '-';
 


### PR DESCRIPTION
Thanks for this great plugin.
I propose a new option `guid` which overrides the random generated `guid`s used in markup and save/restore functions. Having a static `guid` allows for persisting the state of the tree across page loads.