### PR TITLE
Tree-Subelements with custom "data"-attributes lost "data"-attributes

### DIFF
--- a/jquery.bonsai.js
+++ b/jquery.bonsai.js
@@ -202,7 +202,7 @@
           }).first();
       checkbox.val(listItem.data('value'));
       checkbox.prop('checked', listItem.data('checked'))
-      children.remove();
+      children.detach();
       listItem.append(checkbox)
         .append(
           $('<label for="' + id + '">').append(text.length > 0 ? text : children.first())


### PR DESCRIPTION
another suggestion: I use custom $(element).data() attributes on my tree elements. Line 205 used jQuery.remove(), which deletes all events and data. 
I am not sure if events should be removed at this point. But I am sure that remove() is too much :)