### PR TITLE
Implemented setSelected function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gh-pages
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# v2.0
+
+- Add the ability to serialize/restore using any attribute to identify the list items
+- Remove unnecessary entries from serialization data structure (items without ids or children need not be included)
+- Checkbox ids are now sequential - if you want to address a checkbox use a selector that targets ".the-list-item > input"
+- Remove the need for guid, generatedIdPrefix, specifiedIdPrefix and adding generated ids to list items

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ $('#list').bonsai({
   addExpandAll: false, // add a link to expand all items
   addSelectAll: false, // add a link to select all checkboxes
   selectAllExclude: null, // a filter selector or function for selectAll
-  guid: null, // optional guid to support persisting the tree state
 
   // createInputs: create checkboxes or radio buttons for each list item
   // using a value of "checkbox" or "radio".
@@ -73,31 +72,20 @@ $('#list').bonsai('update');
 $('#list').bonsai('expand', listItem);
 ```
 
-### `Bonsai#setSelected( id, state )`
+### `Bonsai#serialize(idAttr = 'id')`
 
-Sets the selected state (indicated by CSS class `selected`) on the item with the specified `id`.
-Also expands the subtree holding the selected list item to make it visible.
-
-The identify of the list item is based on the `id` or `data-bonsai-id` attribute.
-
-```js
-var bonsai = $('#list').data('bonsai');
-bonsai.setSelected( '007', true );
-```
-
-### `Bonsai#serialize()`
-
-Returns an object representing the expanded/collapsed state of the list.
-The identify of the list items for serialize and restore is based on the `id` or `data-bonsai-id` attributes.
+Returns an object representing the expanded/collapsed state of the list, using the items' id 
+(or the attribute specified by `idAttr`) to identify the list items.
 
 ```js
 var bonsai = $('#list').data('bonsai');
 var state = bonsai.serialize();
 ```
 
-### `Bonsai#restore()`
+### `Bonsai#restore(idAttr = 'id')`
 
-Restores the expanded/collapsed state of the list using the return value of `#serialize()`.
+Restores the expanded/collapsed state of the list using the return value of `#serialize()`. 
+The `idAttr` argument must be the same as in the call to `#serialize()`.
 
 ```js
 var bonsai = $('#list').data('bonsai');

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $('#list').bonsai({
   addExpandAll: false, // add a link to expand all items
   addSelectAll: false, // add a link to select all checkboxes
   selectAllExclude: null, // a filter selector or function for selectAll
+  guid: null, // optional guid to support persisting the tree state
 
   // createInputs: create checkboxes or radio buttons for each list item
   // using a value of "checkbox" or "radio".
@@ -70,6 +71,18 @@ $('#list').bonsai('update');
 
 ```js
 $('#list').bonsai('expand', listItem);
+```
+
+### `Bonsai#setSelected( id, state )`
+
+Sets the selected state (indicated by CSS class `selected`) on the item with the specified `id`.
+Also expands the subtree holding the selected list item to make it visible.
+
+The identify of the list item is based on the `id` or `data-bonsai-id` attribute.
+
+```js
+var bonsai = $('#list').data('bonsai');
+bonsai.setSelected( '007', true );
 ```
 
 ### `Bonsai#serialize()`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ $('#list').bonsai('update');
 $('#list').bonsai('expand', listItem);
 ```
 
+### `Bonsai#expandTo(id, idAttr = 'id')`
+
+Expands a subtree up to the item identified by the items' id (or the attribute specified by `idAttr`) 
+and returns the listItem for further processing.
+
+```js
+var bonsai = $('#list').data('bonsai');
+var $li = bonsai.expandTo(id);
+```
+
 ### `Bonsai#serialize(idAttr = 'id')`
 
 Returns an object representing the expanded/collapsed state of the list, using the items' id 
@@ -82,7 +92,7 @@ var bonsai = $('#list').data('bonsai');
 var state = bonsai.serialize();
 ```
 
-### `Bonsai#restore(idAttr = 'id')`
+### `Bonsai#restore(state, idAttr = 'id')`
 
 Restores the expanded/collapsed state of the list using the return value of `#serialize()`. 
 The `idAttr` argument must be the same as in the call to `#serialize()`.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-bonsai",
-  "version": "1.3.0",
+  "version": "2.0.0-beta",
   "main": "jquery.bonsai.js",
   "ignore": [
     "**/.*",

--- a/jquery.bonsai.js
+++ b/jquery.bonsai.js
@@ -189,6 +189,21 @@
         }
       });
     },
+    setSelected: function( id, selected ) {
+      var self = this;
+
+      var $li = self.el.find( '#' + id );
+      if ( $li.length == 0 ) {
+          $li = self.el.find( '#' + this.specifiedIdPrefix + id );
+      }
+      if ( $li.length > 0 ) {
+          $li.parents( 'li' ).each( function() {
+              self.setExpanded( $(this), selected );
+              $(this).toggleClass( 'selected', selected );
+          });
+          $li.toggleClass( 'selected', selected );
+      }
+    },
     insertInput: function(listItem) {
       var type = this.options.createInputs;
       if (listItem.find('> input[type=' + type + ']').length) return;

--- a/jquery.bonsai.js
+++ b/jquery.bonsai.js
@@ -114,6 +114,16 @@
     collapseAll: function() {
       this.collapse(this.el.find('li'));
     },
+    expandTo: function (id, idAttr) {
+      idAttr = idAttr || 'id';
+      var self = this;
+
+      var $li = self.el.find('[' + idAttr + '="' + id + '"]');
+      $li.parents('li').each(function () {
+        self.expand($(this));
+      });
+      return $li;
+    },
     update: function() {
       var self = this;
       // look for a nested list (if any)
@@ -178,21 +188,6 @@
           self.collapse($li);
         }
       });
-    },
-    setSelected: function( id, selected ) {
-      var self = this;
-
-      var $li = self.el.find( '#' + id );
-      if ( $li.length == 0 ) {
-          $li = self.el.find( '#' + this.specifiedIdPrefix + id );
-      }
-      if ( $li.length > 0 ) {
-          $li.parents( 'li' ).each( function() {
-              self.setExpanded( $(this), selected );
-              $(this).toggleClass( 'selected', selected );
-          });
-          $li.toggleClass( 'selected', selected );
-      }
     },
     insertInput: function(listItem) {
       var type = this.options.createInputs;

--- a/jquery.bonsai.js
+++ b/jquery.bonsai.js
@@ -21,7 +21,6 @@
     addExpandAll: false, // add a link to expand all items
     addSelectAll: false, // add a link to select all checkboxes
     selectAllExclude: null, // a filter selector or function for selectAll
-    guid: null, // optional guid to support persisting the tree state
 
     // createInputs: create checkboxes or radio buttons for each list item
     // by setting createInputs to "checkbox" or "radio".
@@ -54,10 +53,6 @@
     this.options = $.extend({}, $.bonsai.defaults, options);
     this.el = $(el).addClass('bonsai').data('bonsai', this);
 
-    this.options.guid = this.options.guid || Math.round(Math.random() * 1e8);
-    this.generatedIdPrefix = 'bonsai-generated-' + this.options.guid + '-';
-    this.specifiedIdPrefix = 'bonsai-specified-' + this.options.guid + '-';
-
     // store the scope in the options for child nodes
     if (!this.options.scope) {
       this.options.scope = this.el;
@@ -65,7 +60,7 @@
     this.update();
     if (this.isRootNode()) {
       if (this.options.createCheckboxes) this.createInputs = 'checkbox';
-      if (this.options.handleDuplicateCheckboxes) this.handleDuplicates();
+      if (this.options.handleDuplicateCheckboxes) this.handleDuplicateCheckboxes();
       if (this.options.checkboxes) this.el.qubit(this.options);
       if (this.options.addExpandAll) this.addExpandAllLink();
       if (this.options.addSelectAll) this.addSelectAllLink();
@@ -104,8 +99,7 @@
       }
       if (expanded) {
         if (!listItem.data('subList')) return;
-        listItem = $(listItem).addClass('expanded')
-          .removeClass('collapsed');
+        listItem = $(listItem).addClass('expanded').removeClass('collapsed');
         $(listItem.data('subList')).css('height', 'auto');
       }
       else {
@@ -157,34 +151,30 @@
 
       this.expand = this.options.expand || this.expand;
       this.collapse = this.options.collapse || this.collapse;
-
-      this.el.find('li').toArray().forEach(function(li) {
-        // liId writes the id to the actual id attribute
-        self.liId($(li));
-      });
     },
-    serialize: function() {
-      var self = this;
-
+    serialize: function(idAttr) {
+      idAttr = idAttr || 'id';
       return this.el.find('li').toArray().reduce(function(acc, li) {
         var $li = $(li);
-        var state =
-              $li.hasClass('expanded') ? 'expanded' :
-              $li.hasClass('collapsed') ? 'collapsed' :
-              null;
-
-        acc[self.liId($li)] = state;
+        var id = $li.attr(idAttr);
+        // only items with IDs can be serialized
+        if (id) {
+          var state = $li.hasClass('expanded')
+              ? 'expanded'
+              : ($li.hasClass('collapsed') ? 'collapsed' : null);
+          if (state) acc[id] = state;
+        }
         return acc;
       }, {});
     },
-    restore: function(state) {
+    restore: function(state, idAttr) {
+      idAttr = idAttr || 'id';
       var self = this;
-
-      Object.keys(state).forEach(function(key) {
-        var $li = self.el.find('#' + key);
-        if (state[key] === 'expanded') {
+      Object.keys(state).forEach(function(id) {
+        var $li = self.el.find('[' + idAttr + '="' + id + '"]');
+        if (state[id] === 'expanded') {
           self.expand($li);
-        } else if (state[key] === 'collapsed') {
+        } else if (state[id] === 'collapsed') {
           self.collapse($li);
         }
       });
@@ -207,15 +197,15 @@
     insertInput: function(listItem) {
       var type = this.options.createInputs;
       if (listItem.find('> input[type=' + type + ']').length) return;
-      var id = this.checkboxId(listItem),
-          checkbox = $('<input type="' + type + '" name="'
-            + this.getCheckboxName(listItem) + '" id="' + id + '" /> '
-          ),
-          children = listItem.children(),
-          // get the first text node for the label
-          text = listItem.contents().filter(function() {
-            return this.nodeType == 3;
-          }).first();
+      var id = this.inputIdFor(listItem);
+      var checkbox = $('<input type="' + type + '" name="'
+        + this.inputNameFor(listItem) + '" id="' + id + '" /> '
+      );
+      var children = listItem.children();
+      // get the first text node for the label
+      var text = listItem.contents().filter(function() {
+        return this.nodeType == 3;
+      }).first();
       checkbox.val(listItem.data('value'));
       checkbox.prop('checked', listItem.data('checked'))
       children.detach();
@@ -225,67 +215,54 @@
         )
         .append(text.length > 0 ? children : children.slice(1));
     },
-    handleDuplicates: function() {
+    checkboxPrefix: 'bonsai-checkbox-',
+    inputIdFor: function(listItem) {
+      var id;
+      do {
+        id = this.checkboxPrefix + Bonsai.uniqueId++;
+      }
+      while ($('#' + id).length > 0);
+      return id;
+    },
+    inputNameFor: function(listItem) {
+      return listItem.data('name')
+        || listItem.parents().filter('[data-name]').data('name');
+    },
+    handleDuplicateCheckboxes: function() {
       var self = this;
       self.el.on('change', 'input[type=checkbox]', function(ev) {
         var checkbox = $(ev.target);
         if (!checkbox.val()) return;
         // select all duplicate checkboxes that need to be updated
         var selector = 'input[type=checkbox]'
-            + '[value="' + checkbox.val() + '"]'
-            + (checkbox.attr('name') ? '[name="' + checkbox.attr('name') + '"]' : '')
-            + (checkbox.prop('checked') ? ':not(:checked)' : ':checked');
+          + '[value="' + checkbox.val() + '"]'
+          + (checkbox.attr('name') ? '[name="' + checkbox.attr('name') + '"]' : '')
+          + (checkbox.prop('checked') ? ':not(:checked)' : ':checked');
         self.el.find(selector).prop({
           checked: checkbox.prop('checked'),
           indeterminate: checkbox.prop('indeterminate')
         }).trigger('change');
       });
     },
-    checkboxPrefix: 'checkbox-',
-    liId: function(listItem) {
-      var id = listItem.attr('id');
-      var dataId = listItem.attr('data-bonsai-id');
-
-      if (id) {
-        // noop
-      } else if (dataId) {
-        id = this.specifiedIdPrefix + dataId;
-      } else {
-        do {
-          id = this.generatedIdPrefix + Bonsai.uniqueId++;
-        }
-        while($('#' + id).length > 0);
-      }
-
-      listItem.attr('id', id);
-      return id;
-    },
-    checkboxId: function(listItem) {
-      return this.checkboxPrefix + this.liId(listItem);
-    },
-    getCheckboxName: function(listItem) {
-      return listItem.data('name')
-        || listItem.parents().filter('[data-name]').data('name');
-    },
     addExpandAllLink: function() {
       var self = this;
       $('<div class="expand-all">')
-        .append($('<a class="all">Expand all</a>')
-          .on('click', function() {
+        .append(
+          $('<a class="all">Expand all</a>').on('click', function() {
             self.expandAll();
           })
         )
         .append('<i class="separator"></i>')
-        .append($('<a class="none">Collapse all</a>')
-          .on('click', function() {
+        .append(
+          $('<a class="none">Collapse all</a>').on('click', function() {
             self.collapseAll();
           })
         )
         .insertBefore(this.el);
     },
     addSelectAllLink: function() {
-      var scope = this.options.scope,
-          self = this;
+      var scope = this.options.scope;
+      var self = this;
       function getCheckboxes() {
         // return all checkboxes that are not in hidden list items
         return scope.find('li')


### PR DESCRIPTION
I am suggesting a `setSelected` function which highlights the currently selected list item and its parents. 

The use case is a menu tree which can thus be "statically" built and responds to the currently loaded page using this function.

The list item is identified by its `id` or `data-bonsai-id` attribute.