### PR TITLE
Fix expandTo() to return deepest listitem instead of highest

### DIFF
--- a/jquery.bonsai.js
+++ b/jquery.bonsai.js
@@ -122,7 +122,8 @@
     },
     expandTo: function(listItem) {
       var self = this;
-      var $li = this.listItem(listItem).parents('li').each(function () {
+      var $li = this.listItem(listItem);
+      $li.parents('li').each(function () {
         self.expand($(this));
       });
       return $li;


### PR DESCRIPTION
Hi @aexmachina, I checked your recent changes, they work out just fine. For `expandTo` however I have a small change: in my opinion it should return the deepest listitem, not to the highest one, in order to be able to process the subtree from bottom to top.