### PR TITLE
Ported CSS to Bootstrap LESS, improved mobile UX

### DIFF
--- a/jquery.bonsai.less
+++ b/jquery.bonsai.less
@@ -1,0 +1,72 @@
+/* ported from jquery.bonsai.css and adapted for mobile use */
+
+/* Variables used:
+
+  @bonsai-breakpoint: @screen-sm-max;  // up to this screen size arrows will be on the right and touchable
+  @bonsai-left-indent: 20px;          // how much each level will be indented on the left
+  @bonsai-tap-width: 30px;            // width of tap area on the right
+
+*/
+
+.bonsai {
+
+  &, li {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    overflow: hidden;
+    position: relative;
+  }
+
+  a {
+    display: block;
+    padding: @padding-base-vertical 0;
+    @media screen and (max-width: @bonsai-breakpoint) {
+      padding: @padding-base-vertical @bonsai-tap-width @padding-base-vertical 0;
+    }
+  }
+
+  @media screen and (max-width: @bonsai-breakpoint) {
+    li li {
+        padding-left: @bonsai-left-indent;
+    }
+  }
+  @media screen and (min-width: (@bonsai-breakpoint + 1)) {
+    li {
+      padding-left: @bonsai-left-indent;
+    }
+  }
+
+  li > .thumb {
+    margin: @font-size-base/4 0 0 -1em; /* negative margin into the padding of the li */
+    position: absolute;
+    cursor: pointer;
+    @media screen and (max-width: @bonsai-breakpoint) {
+      margin: 0;
+      display: inline-block;
+      right: 0;
+      width: @bonsai-tap-width;
+      font-size: @font-size-base*1.5;
+      text-align: right;
+    }
+  }
+
+  li.has-children > .thumb:after {
+    content: '  ▸';
+  }
+
+  li.has-children.expanded > .thumb:after {
+    content: '  ▾';
+  }
+
+  li.collapsed > ol.bonsai {
+    height: 0;
+    overflow: hidden;
+  }
+
+  .all,
+  .none {
+    cursor: pointer;
+  }
+
+}


### PR DESCRIPTION
Hi @aexmachina, this is probably out of the scope what you want to have in your repository. 

Nevertheless it shows the power of your plugin for the use as navigation tree. I have ported your CSS to Bootstrap LESS and added a few twists to improve the usability on mobile devices. There the arrows will be shown on the right with a bigger touchable area. For an example see http://www.therapool.ch/Integrative-Medizin.
Feel free to use or discard it.