### PR TITLE
Only apply styling to direct descendants

### DIFF
--- a/jquery.bonsai.css
+++ b/jquery.bonsai.css
@@ -1,14 +1,14 @@
 @charset "UTF-8";
 
 .bonsai,
-.bonsai li {
+.bonsai > li {
   margin: 0;
   padding: 0;
   list-style: none;
   overflow: hidden;
 }
 
-.bonsai li {
+.bonsai > li {
   position: relative;
   padding-left: 1.3em; /* padding for the thumb */
 }


### PR DESCRIPTION
If `jquery-bonsai` is applied to a list which contains a list itself then the stylesheet would be applied to *all* list items.

This pull request works fine in my use case. I don't know whether it breaks any other use cases though.