### PR TITLE
Allow for multiple nested `ul` and `ol` lists.

### DIFF
--- a/jquery.bonsai.js
+++ b/jquery.bonsai.js
@@ -113,12 +113,12 @@
       if (expanded) {
         if (!$li.data('subList')) return;
         $li = $($li).addClass('expanded').removeClass('collapsed');
-        $($li.data('subList')).css('height', 'auto');
+        $li.children().filter('ol, ul').css('height', 'auto');
       }
       else {
         $li = $($li).addClass('collapsed')
           .removeClass('expanded');
-        $($li.data('subList')).height(0);
+        $li.children().filter('ol, ul').height(0);
       }
       return $li;
     },


### PR DESCRIPTION
I had two `ul` elements inside of a `li` and bonsai was only recognizing the last one. If you look at line 160, you can see that it sets the `subList` data value as the last of the subLists and then the other sub lists are ignored with expanded and collapsing.

The change I made fixes the issue but I'm sure you know better if A) there's a better way to solve this or B) what might break with this change.